### PR TITLE
Add API to get info about all elasticaches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 *.so
 *.dylib
 govuk_example
-server
 bin/*
 
 # Test binary, built with `go test -c`

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -91,6 +91,14 @@ func main() {
 	elastiCacheService = elasticache.NewElastiCacheService(awsClient.GetConfig(), cfg, log)
 	elastiCacheHandler = elasticache.NewElastiCacheHandler(elastiCacheService, log)
 
+	elastiCacheReport := elasticache.NewElastiCacheReport(elastiCacheService, log)
+	err = reportsManager.Register(elastiCacheReport)
+	if err != nil {
+		log.WithError(err).Error().Msg("Failed to register ElastiCache report - ElastiCache reporting will be unavailable")
+	} else {
+		log.Info().Msg("ElastiCache reporting module registered successfully")
+	}
+
 	// Initialize RDS module with error handling
 	log.Info().Msg("Initializing RDS reporting module")
 	rdsService = rds.NewRDSService(awsClient.GetConfig(), cfg, log)
@@ -299,6 +307,7 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 			// Specific report type endpoints
 			reports.GET("/costs", getSpecificReport(reportsManager, "costs", log))
 			reports.GET("/rds", getSpecificReport(reportsManager, "rds", log))
+			reports.GET("/elasticache", getSpecificReport(reportsManager, "elasticache", log))
 		}
 	}
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -315,6 +315,13 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 		router.GET("/applications/:name", getServiceUnavailablePageHandler("Applications service unavailable", log))
 	}
 
+	// ElastiCache pages (only register if handlers are available
+	if elastiCacheHandler != nil {
+		router.GET("/elasticache", elastiCacheHandler.GetElastiCachesPage)
+	} else {
+		router.GET("/elasticache", getServiceUnavailablePageHandler("ElastiCache service unavailable", log))
+	}
+
 	// RDS pages (only register if handlers are available)
 	if rdsHandler != nil {
 		router.GET("/rds", rdsHandler.GetInstancesPage)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"govuk-reports-dashboard/internal/config"
 	"govuk-reports-dashboard/internal/handlers"
 	"govuk-reports-dashboard/internal/modules/costs"
+	"govuk-reports-dashboard/internal/modules/elasticache"
 	"govuk-reports-dashboard/internal/modules/rds"
 	"govuk-reports-dashboard/internal/reports"
 	"govuk-reports-dashboard/pkg/aws"
@@ -27,7 +28,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Configuration error: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	log, err := logger.New(logger.Config{
 		Level:      cfg.Log.Level,
 		Format:     cfg.Log.Format,
@@ -39,7 +40,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Logger error: %v\n", err)
 		os.Exit(1)
 	}
-	
+
 	// Set as global logger
 	log.SetGlobalLogger()
 
@@ -63,6 +64,8 @@ func main() {
 	// Initialize report modules with proper error handling
 	var costService *costs.CostService
 	var applicationService *costs.ApplicationService
+	var elastiCacheService *elasticache.ElastiCacheService
+	var elastiCacheHandler *elasticache.ElastiCacheHandler
 	var rdsService *rds.RDSService
 	var costHandler *costs.CostHandler
 	var applicationHandler *costs.ApplicationHandler
@@ -83,10 +86,15 @@ func main() {
 		log.Info().Msg("Cost reporting module registered successfully")
 	}
 
+	// Initialize ElastiCache module with error handling
+	log.Info().Msg("Initializing ElastiCache reporting module")
+	elastiCacheService = elasticache.NewElastiCacheService(awsClient.GetConfig(), cfg, log)
+	elastiCacheHandler = elasticache.NewElastiCacheHandler(elastiCacheService, log)
+
 	// Initialize RDS module with error handling
 	log.Info().Msg("Initializing RDS reporting module")
 	rdsService = rds.NewRDSService(awsClient.GetConfig(), cfg, log)
-	
+
 	// Create and register RDS report with error handling
 	rdsReport := rds.NewRDSReport(rdsService, log)
 	err = reportsManager.Register(rdsReport)
@@ -104,7 +112,7 @@ func main() {
 	// Initialize handlers with proper null checks
 	log.Info().Msg("Initializing HTTP handlers")
 	healthHandler := handlers.NewHealthHandler()
-	
+
 	// Initialize cost handlers (these should always be available)
 	if costService != nil && applicationService != nil {
 		costHandler = costs.NewCostHandler(costService, log)
@@ -122,7 +130,7 @@ func main() {
 		log.Error().Msg("RDS service not available - RDS handlers will not be initialized")
 	}
 
-	router := setupRouter(cfg, log, healthHandler, costHandler, applicationHandler, rdsHandler, reportsManager)
+	router := setupRouter(cfg, log, healthHandler, costHandler, applicationHandler, elastiCacheHandler, rdsHandler, reportsManager)
 
 	srv := &http.Server{
 		Addr:         cfg.GetBindAddress(),
@@ -156,7 +164,7 @@ func main() {
 	}
 }
 
-func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers.HealthHandler, costHandler *costs.CostHandler, applicationHandler *costs.ApplicationHandler, rdsHandler *rds.RDSHandler, reportsManager *reports.Manager) *gin.Engine {
+func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers.HealthHandler, costHandler *costs.CostHandler, applicationHandler *costs.ApplicationHandler, elastiCacheHandler *elasticache.ElastiCacheHandler, rdsHandler *rds.RDSHandler, reportsManager *reports.Manager) *gin.Engine {
 	if cfg.Server.Environment == "production" {
 		gin.SetMode(gin.ReleaseMode)
 	}
@@ -165,30 +173,30 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 
 	// Request timeout middleware
 	router.Use(handlers.TimeoutMiddleware(30*time.Second, log))
-	
+
 	// Security headers
 	router.Use(handlers.SecurityHeadersMiddleware())
-	
+
 	// CORS with configuration
 	router.Use(handlers.CORSMiddleware(cfg))
-	
+
 	// Rate limiting and bot detection
 	router.Use(handlers.RateLimitMiddleware(log))
-	
+
 	// Structured logging
 	router.Use(handlers.LoggerMiddleware(log))
-	
+
 	// Metrics collection
 	if cfg.Monitoring.MetricsEnabled {
 		router.Use(handlers.MetricsMiddleware(log))
 	}
-	
+
 	// Health check middleware for circuit breaker
 	router.Use(handlers.HealthCheckMiddleware(log))
-	
+
 	// Error handling with panic recovery
 	router.Use(handlers.ErrorHandler(log))
-	
+
 	// Gin's built-in recovery (backup)
 	router.Use(gin.Recovery())
 
@@ -200,6 +208,7 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 	// - /api/applications/:name/services - Get application services
 	// - /api/costs - Legacy cost summary (backwards compatibility)
 	// - /api/costs/summary - Cost module summary
+	// - /api/elasticache/clusters - List ElastiCache clusters
 	// - /api/rds/health - RDS service health check
 	// - /api/rds/summary - RDS summary statistics
 	// - /api/rds/instances - List PostgreSQL instances
@@ -216,7 +225,7 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 	{
 		// Health endpoint (keep at /api/health for backward compatibility)
 		api.GET("/health", healthHandler.HealthCheck)
-		
+
 		// Application endpoints (only register if handlers are available)
 		if applicationHandler != nil {
 			api.GET("/applications", applicationHandler.GetApplications)
@@ -228,11 +237,11 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 			api.GET("/applications/:name", getServiceUnavailableHandler("Applications service unavailable", log))
 			api.GET("/applications/:name/services", getServiceUnavailableHandler("Applications service unavailable", log))
 		}
-		
+
 		// Legacy cost endpoints (keep for backwards compatibility)
 		if costHandler != nil {
 			api.GET("/costs", costHandler.GetCostSummary)
-			
+
 			// Cost module endpoints
 			costs := api.Group("/costs")
 			{
@@ -242,7 +251,16 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 			// Provide service unavailable responses
 			api.GET("/costs", getServiceUnavailableHandler("Cost service unavailable", log))
 		}
-		
+
+		// ElastiCache endpoints (only register if handler is available)
+		elasticache := api.Group("/elasticache")
+		if elastiCacheHandler != nil {
+			elasticache.GET("/clusters", elastiCacheHandler.GetClusters)
+		} else {
+			// Provide service unavailaible responses when ElastiCache is not available
+			elasticache.GET("/clusters", getServiceUnavailableHandler("ElastiCache service unavailaible", log))
+		}
+
 		// RDS endpoints (only register if handler is available)
 		if rdsHandler != nil {
 			rds := api.Group("/rds")
@@ -266,7 +284,7 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 				rds.GET("/outdated", getServiceUnavailableHandler("RDS service unavailable", log))
 			}
 		}
-		
+
 		// Reports endpoints
 		reports := api.Group("/reports")
 		{
@@ -274,7 +292,7 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 			reports.GET("/list", getReportsList(reportsManager, log))       // New cleaner endpoint
 			reports.GET("/summary", getReportsSummary(reportsManager, log)) // Dashboard summary data
 			reports.GET("/:id", getReport(reportsManager, log))             // Individual report by ID
-			
+
 			// Specific report type endpoints
 			reports.GET("/costs", getSpecificReport(reportsManager, "costs", log))
 			reports.GET("/rds", getSpecificReport(reportsManager, "rds", log))
@@ -287,7 +305,7 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 
 	// Web pages
 	router.GET("/", getDashboardPage)
-	
+
 	// Application pages (only register if handlers are available)
 	if applicationHandler != nil {
 		router.GET("/applications", applicationHandler.GetApplicationsPage)
@@ -296,7 +314,7 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 		router.GET("/applications", getServiceUnavailablePageHandler("Applications service unavailable", log))
 		router.GET("/applications/:name", getServiceUnavailablePageHandler("Applications service unavailable", log))
 	}
-	
+
 	// RDS pages (only register if handlers are available)
 	if rdsHandler != nil {
 		router.GET("/rds", rdsHandler.GetInstancesPage)
@@ -314,19 +332,19 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 func getReportsList(manager *reports.Manager, log *logger.Logger) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		reportList := manager.GetAvailableReports(c.Request.Context())
-		
+
 		response := gin.H{
 			"reports": reportList,
 			"count":   len(reportList),
 			"status":  "success",
 		}
-		
+
 		// Add metadata about the reports framework
 		if len(reportList) > 0 {
 			response["framework_version"] = "1.0.0"
 			response["last_updated"] = reportList[0] // This could be enhanced to track actual last update time
 		}
-		
+
 		log.WithField("available_reports", len(reportList)).Info().Msg("Listed available reports")
 		c.JSON(http.StatusOK, response)
 	}
@@ -337,20 +355,20 @@ func getReportsSummary(manager *reports.Manager, log *logger.Logger) gin.Handler
 		params := reports.ReportParams{
 			UseCache: true,
 		}
-		
+
 		summaries, err := manager.GenerateSummary(c.Request.Context(), params)
 		if err != nil {
 			log.WithError(err).Error().Msg("Failed to generate reports summary")
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to generate reports summary",
+				"error":  "Failed to generate reports summary",
 				"status": "error",
 			})
 			return
 		}
-		
+
 		// Get available reports for additional metadata
 		availableReports := manager.GetAvailableReports(c.Request.Context())
-		
+
 		response := gin.H{
 			"summaries": summaries,
 			"count":     len(summaries),
@@ -361,12 +379,12 @@ func getReportsSummary(manager *reports.Manager, log *logger.Logger) gin.Handler
 				"timezone":  "UTC",
 			},
 		}
-		
+
 		log.WithFields(map[string]interface{}{
 			"summary_count": len(summaries),
 			"reports_count": len(availableReports),
 		}).Info().Msg("Generated reports summary for dashboard")
-		
+
 		c.JSON(http.StatusOK, response)
 	}
 }
@@ -380,11 +398,11 @@ func getReport(manager *reports.Manager, log *logger.Logger) gin.HandlerFunc {
 			})
 			return
 		}
-		
+
 		params := reports.ReportParams{
 			UseCache: true,
 		}
-		
+
 		reportData, err := manager.GenerateReport(c.Request.Context(), reportID, params)
 		if err != nil {
 			log.WithError(err).Error().Msg("Failed to generate report")
@@ -393,7 +411,7 @@ func getReport(manager *reports.Manager, log *logger.Logger) gin.HandlerFunc {
 			})
 			return
 		}
-		
+
 		c.JSON(http.StatusOK, reportData)
 	}
 }
@@ -404,17 +422,17 @@ func getSpecificReport(manager *reports.Manager, reportID string, log *logger.Lo
 		params := reports.ReportParams{
 			UseCache: true,
 		}
-		
+
 		reportData, err := manager.GenerateReport(c.Request.Context(), reportID, params)
 		if err != nil {
 			log.WithError(err).WithField("report_id", reportID).Error().Msg("Failed to generate specific report")
 			c.JSON(http.StatusInternalServerError, gin.H{
-				"error": "Failed to generate report",
+				"error":     "Failed to generate report",
 				"report_id": reportID,
 			})
 			return
 		}
-		
+
 		c.JSON(http.StatusOK, reportData)
 	}
 }
@@ -435,7 +453,7 @@ func getServiceUnavailableHandler(message string, log *logger.Logger) gin.Handle
 			"path":   c.Request.URL.Path,
 			"method": c.Request.Method,
 		}).Warn().Msg("Service unavailable - handler not initialized")
-		
+
 		c.JSON(http.StatusServiceUnavailable, gin.H{
 			"error":   "service_unavailable",
 			"message": message,
@@ -451,7 +469,7 @@ func getServiceUnavailablePageHandler(message string, log *logger.Logger) gin.Ha
 			"path":   c.Request.URL.Path,
 			"method": c.Request.Method,
 		}).Warn().Msg("Service unavailable - handler not initialized")
-		
+
 		c.HTML(http.StatusServiceUnavailable, "error.html", gin.H{
 			"title":   "Service Unavailable",
 			"error":   message,

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -208,6 +208,7 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 	// - /api/applications/:name/services - Get application services
 	// - /api/costs - Legacy cost summary (backwards compatibility)
 	// - /api/costs/summary - Cost module summary
+	// - /api/elasticache/health - ElastiCache service health check
 	// - /api/elasticache/clusters - List ElastiCache clusters
 	// - /api/rds/health - RDS service health check
 	// - /api/rds/summary - RDS summary statistics
@@ -255,9 +256,11 @@ func setupRouter(cfg *config.Config, log *logger.Logger, healthHandler *handlers
 		// ElastiCache endpoints (only register if handler is available)
 		elasticache := api.Group("/elasticache")
 		if elastiCacheHandler != nil {
+			elasticache.GET("/health", elastiCacheHandler.GetHealth)
 			elasticache.GET("/clusters", elastiCacheHandler.GetClusters)
 		} else {
 			// Provide service unavailaible responses when ElastiCache is not available
+			elasticache.GET("/health", getServiceUnavailableHandler("ElastiCache service unavailable", log))
 			elasticache.GET("/clusters", getServiceUnavailableHandler("ElastiCache service unavailaible", log))
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/configsources v1.3.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.6.36 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.45 // indirect
+	github.com/aws/aws-sdk-go-v2/service/elasticache v1.46.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.15.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -20,6 +20,8 @@ github.com/aws/aws-sdk-go-v2/internal/ini v1.3.45 h1:hze8YsjSh8Wl1rYa1CJpRmXP21B
 github.com/aws/aws-sdk-go-v2/internal/ini v1.3.45/go.mod h1:lD5M20o09/LCuQ2mE62Mb/iSdSlCNuj6H5ci7tW7OsE=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.25.0 h1:4D5fE3EN/yOTu479hgwZxvzvQlOv/XyhlWfqt6iu1Nc=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.25.0/go.mod h1:QkSNsCakxi2FwgLS6/eaV0S6KCH7Gkj6qmRHA84VZnc=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.46.3 h1:K1KtI95Fkz+2PT0OtVRsZyUzb4zHFMWOXNPkXy7LYDY=
+github.com/aws/aws-sdk-go-v2/service/elasticache v1.46.3/go.mod h1:kI+JDflKNLqdxVmdg2I8A3dmsCcJzAXXz5vKcHsyz9Y=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4 h1:CXV68E2dNqhuynZJPB80bhPQwAKqBWVer887figW6Jc=
 github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.12.4/go.mod h1:/xFi9KtvBXP97ppCz1TAEvU1Uf66qvid89rbem3wCzQ=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.37/go.mod h1:vBmDnwWXWxNPFRMmG2m/3MKOe+xEcMDo1tanpaWCcck=

--- a/internal/modules/elasticache/handlers.go
+++ b/internal/modules/elasticache/handlers.go
@@ -1,0 +1,40 @@
+package elasticache
+
+import (
+	"govuk-reports-dashboard/internal/models"
+	"govuk-reports-dashboard/pkg/logger"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+)
+
+type ElastiCacheHandler struct {
+	elastiCacheService *ElastiCacheService
+	logger             *logger.Logger
+}
+
+func NewElastiCacheHandler(elastiCacheService *ElastiCacheService, logger *logger.Logger) *ElastiCacheHandler {
+	return &ElastiCacheHandler{
+		elastiCacheService: elastiCacheService,
+		logger:             logger,
+	}
+}
+
+func (h *ElastiCacheHandler) GetClusters(c *gin.Context) {
+	h.logger.Info().Msg("Handling request for ElastiCache instances")
+
+	summary, err := h.elastiCacheService.GetAllClusters(c.Request.Context())
+
+	if err != nil {
+		h.logger.WithError(err).Error().Msg("Failed to get ElastiCache Clusters")
+		c.JSON(http.StatusInternalServerError, models.ErrorResponse{
+			Error:   "internal_server_error",
+			Message: "Failed to get ElastiCache clusters",
+			Code:    http.StatusInternalServerError,
+		})
+		return
+	}
+
+	h.logger.WithField("cluster_count", summary.TotalClusters).Info().Msg("Successfully fetched ElastiCache clusters")
+	c.JSON(http.StatusOK, summary)
+}

--- a/internal/modules/elasticache/handlers.go
+++ b/internal/modules/elasticache/handlers.go
@@ -38,3 +38,11 @@ func (h *ElastiCacheHandler) GetClusters(c *gin.Context) {
 	h.logger.WithField("cluster_count", summary.TotalClusters).Info().Msg("Successfully fetched ElastiCache clusters")
 	c.JSON(http.StatusOK, summary)
 }
+
+func (h *ElastiCacheHandler) GetElastiCachesPage(c *gin.Context) {
+	h.logger.Info().Msg("Serving ElastiCaches table page")
+
+	c.HTML(http.StatusOK, "elasticaches.html", gin.H{
+		"title": "ElastiCaches - GOV.UK Reports Dashboard",
+	})
+}

--- a/internal/modules/elasticache/handlers.go
+++ b/internal/modules/elasticache/handlers.go
@@ -46,3 +46,29 @@ func (h *ElastiCacheHandler) GetElastiCachesPage(c *gin.Context) {
 		"title": "ElastiCaches - GOV.UK Reports Dashboard",
 	})
 }
+
+// GetHealth handles GET /api/elasticache/health - checks if ElastiCache service is available
+func (h *ElastiCacheHandler) GetHealth(c *gin.Context) {
+	h.logger.Info().Msg("Handling ElastiCache health check request")
+
+	// Try to list instances to verify AWS connectivity
+	_, err := h.elastiCacheService.GetServerlessCaches(c.Request.Context())
+
+	if err != nil {
+		h.logger.WithError(err).Error().Msg("ElastiCache health check failed")
+		c.JSON(http.StatusServiceUnavailable, gin.H{
+			"status":  "unhealthy",
+			"service": "elasticache",
+			"error":   "Unable to connect to AWS ElastiCache",
+		})
+		return
+	}
+
+	h.logger.Info().Msg("ElastiCache health check passed")
+	c.JSON(http.StatusOK, gin.H{
+		"status":  "healthy",
+		"service": "elasticache",
+		"message": "AWS ElastiCache connectivity verified",
+	})
+}
+

--- a/internal/modules/elasticache/models.go
+++ b/internal/modules/elasticache/models.go
@@ -1,33 +1,41 @@
 package elasticache
 
+import (
+	"time"
+)
+
 type CacheClusterEncyrptionConfig struct {
 	AtRest    bool `json:"at_rest"`
 	InTransit bool `json:"in_trasit"`
 }
 
 type ElastiCacheCluster struct {
-	ARN              string                       `json:"arn"`
-	Id               string                       `json:"cache_cluster_id"`
-	NodeType         string                       `json:"cache_node_type"`
-	NumCacheNodes    int32                        `json:"num_cache_nodes"`
-	Engine           string                       `json:"engine"`
-	EngineVersion    string                       `json:"engine_version"`
-	Status           string                       `json:"status"`
-	EncryptionConfig CacheClusterEncyrptionConfig `json:"encryption_config"`
-	ReplicationGroup string                       `json:"replication_group"`
+	ARN                           string                                `json:"arn"`
+	Id                            string                                `json:"cache_cluster_id"`
+	NodeType                      string                                `json:"cache_node_type"`
+	NumCacheNodes                 int32                                 `json:"num_cache_nodes"`
+	Engine                        string                                `json:"engine"`
+	EngineVersion                 string                                `json:"engine_version"`
+	Status                        string                                `json:"status"`
+	EncryptionConfig              CacheClusterEncyrptionConfig          `json:"encryption_config"`
+	ReplicationGroup              string                                `json:"replication_group"`
+	UnappliedUpdateActionsSummary ElastiCacheUpdateActionsSummary       `json:"update_action_summary"`
+	UnappliedUpdateActions        []ElastiCacheCacheClusterUpdateAction `json:"update_actions"`
 }
 
 type ElastiCacheReplicationGroup struct {
-	ARN              string                       `json:"arn"`
-	Id               string                       `json:"replication_group_id"`
-	NodeType         string                       `json:"cache_node_type"`
-	Status           string                       `json:"status"`
-	MemberClusters   []ElastiCacheCluster         `json:"member_clusters"`
-	MultiAZ          string                       `json:"multi_az"`
-	ClusterEnabled   bool                         `json:"cluster_enabled"`
-	ClusterMode      string                       `json:"cluster_mode"`
-	Engine           string                       `json:"engine"`
-	EncryptionConfig CacheClusterEncyrptionConfig `json:"encryption_config"`
+	ARN                           string                                    `json:"arn"`
+	Id                            string                                    `json:"replication_group_id"`
+	NodeType                      string                                    `json:"cache_node_type"`
+	Status                        string                                    `json:"status"`
+	MemberClusters                []ElastiCacheCluster                      `json:"member_clusters"`
+	MultiAZ                       string                                    `json:"multi_az"`
+	ClusterEnabled                bool                                      `json:"cluster_enabled"`
+	ClusterMode                   string                                    `json:"cluster_mode"`
+	Engine                        string                                    `json:"engine"`
+	EncryptionConfig              CacheClusterEncyrptionConfig              `json:"encryption_config"`
+	UnappliedUpdateActionsSummary ElastiCacheUpdateActionsSummary           `json:"update_action_summary"`
+	UnappliedUpdateActions        []ElastiCacheReplicationGroupUpdateAction `json:"update_actions"`
 }
 
 type ElastiCacheServerlessCache struct {
@@ -39,18 +47,60 @@ type ElastiCacheServerlessCache struct {
 	FullEngineVersion  string `json:"full_engine_version"`
 }
 
+type ElastiCacheUpdateActionsSummary struct {
+	UnappliedUpdateCount               int `json:"total_unapplied_updates"`
+	TotalUnappliedImportantUpdateCount int `json:"total_uapplied_important_updates"`
+	TotalUnappliedCriticalUpdateCount  int `json:"total_uapplied_critical_updates"`
+}
+
+type ElastiCacheReplicationGroupUpdateAction struct {
+	ReplicationGroupId string                  `json:"replication_group_id"`
+	UpdateAction       ElastiCacheUpdateAction `json:"update_action"`
+}
+
+type ElastiCacheCacheClusterUpdateAction struct {
+	CacheClusterId string                  `json:"replication_group_id"`
+	UpdateAction   ElastiCacheUpdateAction `json:"update_action"`
+}
+
+type ElastiCacheUpdateAction struct {
+	ServiceUpdate      ElastiCacheServiceUpdate                `json:"service_update"`
+	AvailableDate      time.Time                               `json:"available_date"`
+	Status             string                                  `json:"update_action_status"`
+	StatusModifiedDate time.Time                               `json:"udpate_action_status_modified_date"`
+	Completion         ElastiCacheUpdateActionCompletionStatus `json:"completion_status"`
+	SlaMet             string                                  `json:"sla_met"`
+	Engine             string                                  `json:"engine"`
+}
+
+type ElastiCacheServiceUpdate struct {
+	Name                   string    `json:"name"`
+	ReleaseDate            time.Time `json:"release_date"`
+	Severity               string    `json:"severity"`
+	Status                 string    `json:"status"`
+	RecommendedApplyByDate time.Time `json:"recommended_apply_by_date"`
+	Type                   string    `json:"type"`
+}
+
+type ElastiCacheUpdateActionCompletionStatus struct {
+	TotalNodesToUpdate          int `json:"total_nodes_to_update"`
+	TotalNodesAlreadyUpdated    int `json:"total_nodes_already_updated"`
+	TotalNodesRemainingToUpdate int `json:"total_nodes_remaining_to_update"`
+}
+
 type CacheClustersSummary struct {
-	TotalClusters              int                           `json:"total_clusters"`
-	TotalServerlessCaches      int                           `json:"total_serverless_caches"`
-	TotalNodes                 int32                         `json:"total_nodes"`
-	ValkeyCount                int                           `json:"valkey_count"`
-	ValkeyNodesCount           int32                         `json:"valkey_nodes_count"`
-	RedisCount                 int                           `json:"redis_count"`
-	RedisNodesCount            int32                         `json:"redis_nodes_count"`
-	MemcachedCount             int                           `json:"memcached_count"`
-	MemcachedNodesCount        int32                         `json:"memcached_nodes_count"`
-	AllCacheClusters           []ElastiCacheCluster          `json:"all_cache_clusters"`
-	ReplicationGroups          []ElastiCacheReplicationGroup `json:"replication_groups"`
-	NonReplicatedCacheClusters []ElastiCacheCluster          `json:"non_replicationed_cache_clusters"`
-	ServerlessCaches           []ElastiCacheServerlessCache  `json:"serverless_caches"`
+	TotalClusters                 int                             `json:"total_clusters"`
+	TotalServerlessCaches         int                             `json:"total_serverless_caches"`
+	TotalNodes                    int32                           `json:"total_nodes"`
+	ValkeyCount                   int                             `json:"valkey_count"`
+	ValkeyNodesCount              int32                           `json:"valkey_nodes_count"`
+	RedisCount                    int                             `json:"redis_count"`
+	RedisNodesCount               int32                           `json:"redis_nodes_count"`
+	MemcachedCount                int                             `json:"memcached_count"`
+	MemcachedNodesCount           int32                           `json:"memcached_nodes_count"`
+	AllCacheClusters              []ElastiCacheCluster            `json:"all_cache_clusters"`
+	ReplicationGroups             []ElastiCacheReplicationGroup   `json:"replication_groups"`
+	NonReplicatedCacheClusters    []ElastiCacheCluster            `json:"non_replicationed_cache_clusters"`
+	ServerlessCaches              []ElastiCacheServerlessCache    `json:"serverless_caches"`
+	UnappliedUpdateActionsSummary ElastiCacheUpdateActionsSummary `json:"unapplied_update_actions_summary"`
 }

--- a/internal/modules/elasticache/models.go
+++ b/internal/modules/elasticache/models.go
@@ -1,0 +1,56 @@
+package elasticache
+
+type CacheClusterEncyrptionConfig struct {
+	AtRest    bool `json:"at_rest"`
+	InTransit bool `json:"in_trasit"`
+}
+
+type ElastiCacheCluster struct {
+	ARN              string                       `json:"arn"`
+	Id               string                       `json:"cache_cluster_id"`
+	NodeType         string                       `json:"cache_node_type"`
+	NumCacheNodes    int32                        `json:"num_cache_nodes"`
+	Engine           string                       `json:"engine"`
+	EngineVersion    string                       `json:"engine_version"`
+	Status           string                       `json:"status"`
+	EncryptionConfig CacheClusterEncyrptionConfig `json:"encryption_config"`
+	ReplicationGroup string                       `json:"replication_group"`
+}
+
+type ElastiCacheReplicationGroup struct {
+	ARN              string                       `json:"arn"`
+	Id               string                       `json:"replication_group_id"`
+	NodeType         string                       `json:"cache_node_type"`
+	Status           string                       `json:"status"`
+	MemberClusters   []ElastiCacheCluster         `json:"member_clusters"`
+	MultiAZ          string                       `json:"multi_az"`
+	ClusterEnabled   bool                         `json:"cluster_enabled"`
+	ClusterMode      string                       `json:"cluster_mode"`
+	Engine           string                       `json:"engine"`
+	EncryptionConfig CacheClusterEncyrptionConfig `json:"encryption_config"`
+}
+
+type ElastiCacheServerlessCache struct {
+	ARN                string `json:"arn"`
+	Name               string `json:"serverless_cache_name"`
+	Status             string `json:"status"`
+	Engine             string `json:"engine"`
+	MajorEngineVersion string `json:"major_engine_version"`
+	FullEngineVersion  string `json:"full_engine_version"`
+}
+
+type CacheClustersSummary struct {
+	TotalClusters              int                           `json:"total_clusters"`
+	TotalServerlessCaches      int                           `json:"total_serverless_caches"`
+	TotalNodes                 int32                         `json:"total_nodes"`
+	ValkeyCount                int                           `json:"valkey_count"`
+	ValkeyNodesCount           int32                         `json:"valkey_nodes_count"`
+	RedisCount                 int                           `json:"redis_count"`
+	RedisNodesCount            int32                         `json:"redis_nodes_count"`
+	MemcachedCount             int                           `json:"memcached_count"`
+	MemcachedNodesCount        int32                         `json:"memcached_nodes_count"`
+	AllCacheClusters           []ElastiCacheCluster          `json:"all_cache_clusters"`
+	ReplicationGroups          []ElastiCacheReplicationGroup `json:"replication_groups"`
+	NonReplicatedCacheClusters []ElastiCacheCluster          `json:"non_replicationed_cache_clusters"`
+	ServerlessCaches           []ElastiCacheServerlessCache  `json:"serverless_caches"`
+}

--- a/internal/modules/elasticache/models.go
+++ b/internal/modules/elasticache/models.go
@@ -49,8 +49,8 @@ type ElastiCacheServerlessCache struct {
 
 type ElastiCacheUpdateActionsSummary struct {
 	UnappliedUpdateCount               int `json:"total_unapplied_updates"`
-	TotalUnappliedImportantUpdateCount int `json:"total_uapplied_important_updates"`
-	TotalUnappliedCriticalUpdateCount  int `json:"total_uapplied_critical_updates"`
+	TotalUnappliedImportantUpdateCount int `json:"total_unapplied_important_updates"`
+	TotalUnappliedCriticalUpdateCount  int `json:"total_unapplied_critical_updates"`
 }
 
 type ElastiCacheReplicationGroupUpdateAction struct {
@@ -100,7 +100,7 @@ type CacheClustersSummary struct {
 	MemcachedNodesCount           int32                           `json:"memcached_nodes_count"`
 	AllCacheClusters              []ElastiCacheCluster            `json:"all_cache_clusters"`
 	ReplicationGroups             []ElastiCacheReplicationGroup   `json:"replication_groups"`
-	NonReplicatedCacheClusters    []ElastiCacheCluster            `json:"non_replicationed_cache_clusters"`
+	NonReplicatedCacheClusters    []ElastiCacheCluster            `json:"non_replicated_cache_clusters"`
 	ServerlessCaches              []ElastiCacheServerlessCache    `json:"serverless_caches"`
 	UnappliedUpdateActionsSummary ElastiCacheUpdateActionsSummary `json:"unapplied_update_actions_summary"`
 }

--- a/internal/modules/elasticache/report.go
+++ b/internal/modules/elasticache/report.go
@@ -1,0 +1,62 @@
+package elasticache
+
+import (
+	"context"
+	"time"
+
+	"govuk-reports-dashboard/internal/reports"
+	"govuk-reports-dashboard/pkg/logger"
+)
+
+type ElastiCacheReport struct {
+	elastiCacheService *ElastiCacheService
+	renderer           *reports.Renderer
+	logger             *logger.Logger
+}
+
+func NewElastiCacheReport(elastiCacheService *ElastiCacheService, logger *logger.Logger) *ElastiCacheReport {
+	return &ElastiCacheReport{
+		elastiCacheService: elastiCacheService,
+		renderer:           reports.NewRenderer(),
+		logger:             logger,
+	}
+}
+
+func (e *ElastiCacheReport) GetMetadata() reports.ReportMetadata {
+	return reports.ReportMetadata{
+		ID:          "elasticache",
+		Name:        "ElastiCache patching report",
+		Description: "ElastiCache discovery and patch compliance checking",
+		Type:        reports.ReportTypeHealth,
+		Version:     "1.0.0",
+		Author:      "GOV.UK Platform Team",
+		Tags:        []string{"elasticache", "redis", "valkey", "memcached", "versions", "patching"},
+		Priority:    reports.PriorityMedium,
+	}
+}
+
+func (e *ElastiCacheReport) GenerateSummary(ctx context.Context, params reports.ReportParams) ([]reports.Summary, error) {
+	// TODO
+	return []reports.Summary{}, nil
+}
+
+func (e *ElastiCacheReport) GenerateReport(ctx context.Context, params reports.ReportParams) (reports.ReportData, error) {
+	// TODO
+	return reports.ReportData{}, nil
+}
+
+func (e *ElastiCacheReport) IsAvailable(ctx context.Context) bool {
+	_, err := e.elastiCacheService.GetServerlessCaches(ctx)
+	return err == nil
+}
+
+// GetRefreshInterval returns how often this report should be refreshed
+func (e *ElastiCacheReport) GetRefreshInterval() time.Duration {
+	return 30 * time.Minute // Refresh every 30 minutes (ElastiCache data changes less frequently)
+}
+
+// Validate checks if the provided parameters are valid for this report
+func (e *ElastiCacheReport) Validate(params reports.ReportParams) error {
+	// ElastiCache reports don't have specific parameter requirements currently
+	return nil
+}

--- a/internal/modules/elasticache/service.go
+++ b/internal/modules/elasticache/service.go
@@ -1,0 +1,224 @@
+package elasticache
+
+import (
+	"context"
+	"fmt"
+
+	"govuk-reports-dashboard/internal/config"
+	"govuk-reports-dashboard/pkg/logger"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache/types"
+)
+
+type ElastiCacheService struct {
+	client *elasticache.Client
+	config *config.Config
+	logger *logger.Logger
+}
+
+// NewElastiCacheService creates a new ElastiCache service instance
+func NewElastiCacheService(awsConfig aws.Config, config *config.Config, logger *logger.Logger) *ElastiCacheService {
+	client := elasticache.NewFromConfig(awsConfig)
+
+	return &ElastiCacheService{
+		client: client,
+		config: config,
+		logger: logger,
+	}
+}
+
+func (s *ElastiCacheService) GetAllClusters(ctx context.Context) (*CacheClustersSummary, error) {
+	s.logger.Info().Msg("Discovering ElastiCache clusters")
+
+	cacheClusters, err := s.getCacheClusters(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	replicationGroups, err := s.getReplicationGroups(cacheClusters, ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	serverlessCaches, err := s.getServerlessCaches(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	summary := s.generateCacheClustersSummary(replicationGroups, cacheClusters, serverlessCaches)
+
+	return summary, nil
+}
+
+func (s *ElastiCacheService) getCacheClusters(ctx context.Context) ([]ElastiCacheCluster, error) {
+	var cacheClusters []ElastiCacheCluster
+
+	paginator := elasticache.NewDescribeCacheClustersPaginator(s.client, &elasticache.DescribeCacheClustersInput{})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			s.logger.WithError(err).Error().Msg("Failed to describe ElastiCache Clusters")
+			return nil, fmt.Errorf("failed to describe ElastiCache clusters: %w", err)
+		}
+
+		for _, cacheCluster := range page.CacheClusters {
+			cacheClusters = append(cacheClusters, s.convertToElastiCacheCluster(cacheCluster))
+		}
+
+	}
+
+	return cacheClusters, nil
+}
+
+func (s *ElastiCacheService) getReplicationGroups(cacheClusters []ElastiCacheCluster, ctx context.Context) ([]ElastiCacheReplicationGroup, error) {
+	var replicationGroups []ElastiCacheReplicationGroup
+
+	paginator := elasticache.NewDescribeReplicationGroupsPaginator(s.client, &elasticache.DescribeReplicationGroupsInput{})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			s.logger.WithError(err).Error().Msg("Failed to describe ElastiCache replication groups")
+			return nil, fmt.Errorf("failed to describe ElastiCache replication groups: %w", err)
+		}
+
+		for _, replicationGroup := range page.ReplicationGroups {
+			replicationGroups = append(replicationGroups, s.convertToElastiCacheReplicationGroup(replicationGroup, cacheClusters))
+		}
+	}
+
+	return replicationGroups, nil
+}
+
+func (s *ElastiCacheService) getServerlessCaches(ctx context.Context) ([]ElastiCacheServerlessCache, error) {
+	var serverlessCaches []ElastiCacheServerlessCache
+
+	paginator := elasticache.NewDescribeServerlessCachesPaginator(s.client, &elasticache.DescribeServerlessCachesInput{})
+
+	for paginator.HasMorePages() {
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			s.logger.WithError(err).Error().Msg("Failed to describe ElastiCache serverless caches")
+			return nil, fmt.Errorf("failed to describe ElastiCache serverless caches: %w", err)
+		}
+
+		for _, serverlessCache := range page.ServerlessCaches {
+			serverlessCaches = append(serverlessCaches, s.convertToServerlessElastiCache(serverlessCache))
+		}
+	}
+
+	return serverlessCaches, nil
+}
+
+func (s *ElastiCacheService) convertToElastiCacheCluster(cacheCluster types.CacheCluster) ElastiCacheCluster {
+	return ElastiCacheCluster{
+		ARN:           aws.ToString(cacheCluster.ARN),
+		Id:            aws.ToString(cacheCluster.CacheClusterId),
+		NodeType:      aws.ToString(cacheCluster.CacheNodeType),
+		NumCacheNodes: aws.ToInt32(cacheCluster.NumCacheNodes),
+		Engine:        aws.ToString(cacheCluster.Engine),
+		EngineVersion: aws.ToString(cacheCluster.EngineVersion),
+		Status:        aws.ToString(cacheCluster.CacheClusterStatus),
+		EncryptionConfig: CacheClusterEncyrptionConfig{
+			AtRest:    aws.ToBool(cacheCluster.AtRestEncryptionEnabled),
+			InTransit: aws.ToBool(cacheCluster.TransitEncryptionEnabled),
+		},
+		ReplicationGroup: aws.ToString(cacheCluster.ReplicationGroupId),
+	}
+}
+
+func (s *ElastiCacheService) convertToServerlessElastiCache(serverlessCache types.ServerlessCache) ElastiCacheServerlessCache {
+	return ElastiCacheServerlessCache{
+		ARN:                aws.ToString(serverlessCache.ARN),
+		Name:               aws.ToString(serverlessCache.ServerlessCacheName),
+		Status:             aws.ToString(serverlessCache.Status),
+		Engine:             aws.ToString(serverlessCache.Engine),
+		MajorEngineVersion: aws.ToString(serverlessCache.MajorEngineVersion),
+		FullEngineVersion:  aws.ToString(serverlessCache.FullEngineVersion),
+	}
+}
+
+func (s *ElastiCacheService) convertToElastiCacheReplicationGroup(replicationGroup types.ReplicationGroup, cacheClusters []ElastiCacheCluster) ElastiCacheReplicationGroup {
+	var memberClusters []ElastiCacheCluster
+
+	replicationGroupId := aws.ToString(replicationGroup.ReplicationGroupId)
+
+	for _, cluster := range cacheClusters {
+		if cluster.ReplicationGroup == replicationGroupId {
+			memberClusters = append(memberClusters, cluster)
+		}
+	}
+
+	return ElastiCacheReplicationGroup{
+		ARN:            aws.ToString(replicationGroup.ARN),
+		Id:             replicationGroupId,
+		NodeType:       aws.ToString(replicationGroup.CacheNodeType),
+		Status:         aws.ToString(replicationGroup.Status),
+		MemberClusters: memberClusters,
+		MultiAZ:        aws.ToString((*string)(&replicationGroup.MultiAZ)),
+		ClusterEnabled: aws.ToBool(replicationGroup.ClusterEnabled),
+		ClusterMode:    aws.ToString((*string)(&replicationGroup.ClusterMode)),
+		Engine:         aws.ToString(replicationGroup.Engine),
+		EncryptionConfig: CacheClusterEncyrptionConfig{
+			AtRest:    aws.ToBool(replicationGroup.AtRestEncryptionEnabled),
+			InTransit: aws.ToBool(replicationGroup.TransitEncryptionEnabled),
+		},
+	}
+}
+
+func (s *ElastiCacheService) generateCacheClustersSummary(replicationGroups []ElastiCacheReplicationGroup, cacheClusters []ElastiCacheCluster, serverlessCaches []ElastiCacheServerlessCache) *CacheClustersSummary {
+	var valkeyCount, redisCount, memcachedCount int = 0, 0, 0
+	var totalNodes, valkeyNodeCount, redisNodeCount, memcachedNodeCount int32 = 0, 0, 0, 0
+
+	for _, cluster := range cacheClusters {
+		switch cluster.Engine {
+		case "memcached":
+			memcachedCount += 1
+			memcachedNodeCount = valkeyNodeCount + cluster.NumCacheNodes
+		case "redis":
+			redisCount += 1
+			redisNodeCount = valkeyNodeCount + cluster.NumCacheNodes
+		case "valkey":
+			valkeyCount += 1
+			valkeyNodeCount = valkeyNodeCount + cluster.NumCacheNodes
+		}
+		totalNodes = totalNodes + cluster.NumCacheNodes
+	}
+
+	for _, serverlessCache := range serverlessCaches {
+		switch serverlessCache.Engine {
+		case "memcached":
+			memcachedCount += 1
+		case "redis":
+			redisCount += 1
+		case "valkey":
+			valkeyCount += 1
+		}
+	}
+
+	var nonReplicatedCacheClusters []ElastiCacheCluster
+	for _, cacheCluster := range cacheClusters {
+		if cacheCluster.ReplicationGroup == "" {
+			nonReplicatedCacheClusters = append(nonReplicatedCacheClusters, cacheCluster)
+		}
+	}
+
+	return &CacheClustersSummary{
+		TotalClusters:              len(cacheClusters),
+		TotalServerlessCaches:      len(serverlessCaches),
+		TotalNodes:                 totalNodes,
+		MemcachedCount:             memcachedCount,
+		MemcachedNodesCount:        memcachedNodeCount,
+		RedisCount:                 redisCount,
+		RedisNodesCount:            redisNodeCount,
+		ValkeyCount:                valkeyCount,
+		ValkeyNodesCount:           valkeyNodeCount,
+		AllCacheClusters:           cacheClusters,
+		ReplicationGroups:          replicationGroups,
+		NonReplicatedCacheClusters: nonReplicatedCacheClusters,
+		ServerlessCaches:           serverlessCaches,
+	}
+}

--- a/internal/modules/elasticache/service.go
+++ b/internal/modules/elasticache/service.go
@@ -45,7 +45,7 @@ func (s *ElastiCacheService) GetAllClusters(ctx context.Context) (*CacheClusters
 		return nil, err
 	}
 
-	serverlessCaches, err := s.getServerlessCaches(ctx)
+	serverlessCaches, err := s.GetServerlessCaches(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func (s *ElastiCacheService) getCacheClusterUpdateActions(cacheClusters []Elasti
 	return cacheClusterUpdateActions, nil
 }
 
-func (s *ElastiCacheService) getServerlessCaches(ctx context.Context) ([]ElastiCacheServerlessCache, error) {
+func (s *ElastiCacheService) GetServerlessCaches(ctx context.Context) ([]ElastiCacheServerlessCache, error) {
 	var serverlessCaches []ElastiCacheServerlessCache
 
 	paginator := elasticache.NewDescribeServerlessCachesPaginator(s.client, &elasticache.DescribeServerlessCachesInput{})

--- a/web/static/js/elasticache.js
+++ b/web/static/js/elasticache.js
@@ -1,5 +1,5 @@
-// GOV.UK Reports Dashboard - RDS Module JavaScript
-// Handles RDS instances table, filtering, sorting, and data loading
+// GOV.UK Reports Dashboard - ElastiCache Module JavaScript
+// Handles ElastiCache caches table and data loading
 
 class ElastiCachesPage {
     constructor() {

--- a/web/static/js/elasticache.js
+++ b/web/static/js/elasticache.js
@@ -1,0 +1,880 @@
+// GOV.UK Reports Dashboard - RDS Module JavaScript
+// Handles RDS instances table, filtering, sorting, and data loading
+
+class ElastiCachesPage {
+    constructor() {
+        this.instances = [];
+        this.filteredInstances = [];
+        this.currentSort = { field: 'instance_id', direction: 'asc' };
+        this.currentFilter = 'all';
+        this.currentSearch = '';
+        
+        this.init();
+    }
+
+    init() {
+        this.setupEventListeners();
+        this.loadElastiCacheData();
+    }
+
+    setupEventListeners() {
+        // // Search functionality
+        // const searchInput = document.getElementById('search-instances');
+        // if (searchInput) {
+        //     searchInput.addEventListener('input', (e) => {
+        //         this.handleSearch(e.target.value);
+        //     });
+        // }
+
+        // // Filter buttons
+        // const filterButtons = document.querySelectorAll('[data-filter]');
+        // filterButtons.forEach(button => {
+        //     button.addEventListener('click', (e) => {
+        //         e.preventDefault();
+        //         this.handleFilter(e.target.dataset.filter);
+        //         this.setActiveFilter(e.target);
+        //     });
+        // });
+
+        // // Sort functionality
+        // const sortableHeaders = document.querySelectorAll('.sortable');
+        // sortableHeaders.forEach(header => {
+        //     header.addEventListener('click', (e) => {
+        //         this.handleSort(e.currentTarget.dataset.sort);
+        //     });
+        // });
+
+        // Action buttons
+        const retryButton = document.getElementById('retry-button');
+        if (retryButton) {
+            retryButton.addEventListener('click', () => {
+                this.loadElastiCacheData();
+            });
+        }
+
+        // const refreshButton = document.getElementById('refresh-data');
+        // if (refreshButton) {
+        //     refreshButton.addEventListener('click', () => {
+        //         this.loadRDSData();
+        //     });
+        // }
+
+        // const clearFiltersButton = document.getElementById('clear-filters');
+        // if (clearFiltersButton) {
+        //     clearFiltersButton.addEventListener('click', () => {
+        //         this.clearAllFilters();
+        //     });
+        // }
+    }
+
+    async loadElastiCacheData() {
+        this.showLoading();
+        this.hideError();
+
+        try {
+            // Load summary and instances data in parallel
+            // const [summaryResponse, instancesResponse] = await Promise.all([
+            //     fetch('/api/rds/summary'),
+            //     fetch('/api/rds/instances')
+            // ]);
+          //
+            const summaryResponse = await fetch('/api/elasticache/clusters')
+
+            if (!summaryResponse.ok) {
+                throw new Error(`Failed to load summary: HTTP ${summaryResponse.status}`);
+            }
+            // if (!instancesResponse.ok) {
+            //     throw new Error(`Failed to load instances: HTTP ${instancesResponse.status}`);
+            // }
+
+            const summaryData = await summaryResponse.json();
+            // const instancesData = await instancesResponse.json();
+
+            this.updateSummaryCards(summaryData);
+            // this.instances = instancesData.instances || [];
+            // this.filteredInstances = [...this.instances];
+            
+            // this.renderInstances();
+            // this.renderVersionChart();
+            // this.showInstancesTable();
+            this.hideLoading();
+
+        } catch (error) {
+            console.error('Failed to load ElastiCache data:', error);
+            this.showError(error.message);
+            this.hideLoading();
+        }
+    }
+
+    updateSummaryCards(data) {
+        const totalCaches = (data.total_clusters + data.total_serverless_caches) || '0';
+        const unappliedUpdates = data.unapplied_update_actions_summary.total_unapplied_updates || '0'; 
+        const unappliedImportantUpdates = data.unapplied_update_actions_summary.total_unapplied_important_updates || '0';
+        const unappliedCriticalUpdates =  data.unapplied_update_actions_summary.total_unapplied_critical_updates || '0';
+
+        // Update summary metrics
+        document.getElementById('total-elasticaches').textContent = totalCaches;
+        document.getElementById('unapplied-updates').textContent = unappliedUpdates;
+        document.getElementById('unapplied-important-updates').textContent = unappliedImportantUpdates;
+        document.getElementById('unapplied-critical-updates').textContent = unappliedCriticalUpdates;
+        
+        /// // Calculate and display compliance percentage
+        /// const total = data.postgresql_count || 0;
+        /// const eol = data.eol_instances || 0;
+        /// const outdated = data.outdated_instances || 0;
+        /// const compliant = total - eol - outdated;
+        /// const compliancePercentage = total > 0 ? ((compliant / total) * 100).toFixed(1) : '0';
+        /// document.getElementById('compliance-rate').textContent = `${compliancePercentage}%`;
+
+        // Update card styling based on values
+        this.updateCardStyling('unapplied-critical-updates', unappliedCriticalUpdates);
+        this.updateCardStyling('unapplied-important-updates', unappliedImportantUpdates);
+    }
+
+    updateCardStyling(elementId, value) {
+        const element = document.getElementById(elementId);
+        const card = element.closest('.elasticache-summary-card');
+        
+        if (value > 0) {
+            if (elementId === 'unapplied-critical-updates') {
+                card.classList.add('elasticache-summary-card--critical');
+            } else if (elementId === 'unapplied-important-updates') {
+                card.classList.add('elasticache-summary-card--warning');
+            }
+        } else {
+            card.classList.remove('elasticache-summary-card--critical', 'elasticache-summary-card--warning');
+        }
+    }
+
+///    renderInstances() {
+///        const tbody = document.getElementById('instances-tbody');
+///        
+///        if (!tbody) return;
+///
+///        // Clear existing content
+///        tbody.innerHTML = '';
+///
+///        if (this.filteredInstances.length === 0) {
+///            this.showNoResults();
+///            return;
+///        }
+///
+///        this.hideNoResults();
+///
+///        // Sort instances
+///        this.sortInstances();
+///
+///        // Render each instance
+///        this.filteredInstances.forEach(instance => {
+///            const row = this.createInstanceRow(instance);
+///            tbody.appendChild(row);
+///        });
+///
+///        // Update footer stats
+///        this.updateTableFooter();
+///    }
+///
+///    createInstanceRow(instance) {
+///        const row = document.createElement('tr');
+///        row.className = 'govuk-table__row';
+///        
+///        // Apply styling based on compliance status
+///        const complianceStatus = this.getComplianceStatus(instance);
+///        if (complianceStatus === 'eol') {
+///            row.classList.add('rds-row--critical');
+///        } else if (complianceStatus === 'outdated') {
+///            row.classList.add('rds-row--warning');
+///        }
+///        
+///        // Instance ID (with link to detail page)
+///        const idCell = document.createElement('td');
+///        idCell.className = 'govuk-table__cell';
+///        const idLink = document.createElement('a');
+///        idLink.href = `/rds/${encodeURIComponent(instance.instance_id)}`;
+///        idLink.className = 'govuk-link';
+///        idLink.textContent = instance.instance_id;
+///        idCell.appendChild(idLink);
+///        
+///        // Application
+///        const appCell = document.createElement('td');
+///        appCell.className = 'govuk-table__cell';
+///        appCell.textContent = instance.application || 'Unknown';
+///        
+///        // Environment
+///        const envCell = document.createElement('td');
+///        envCell.className = 'govuk-table__cell';
+///        const envTag = document.createElement('span');
+///        envTag.className = `environment-tag environment-tag--${(instance.environment || 'unknown').toLowerCase()}`;
+///        envTag.textContent = instance.environment || 'Unknown';
+///        envCell.appendChild(envTag);
+///        
+///        // Version
+///        const versionCell = document.createElement('td');
+///        versionCell.className = 'govuk-table__cell';
+///        versionCell.innerHTML = `
+///            <span class="version-info">
+///                ${instance.version}
+///                <small class="version-major">(v${instance.major_version})</small>
+///            </span>
+///        `;
+///        
+///        // Compliance Status
+///        const complianceCell = document.createElement('td');
+///        complianceCell.className = 'govuk-table__cell';
+///        const complianceTag = this.createComplianceTag(instance);
+///        complianceCell.appendChild(complianceTag);
+///        
+///        // Instance Class
+///        const classCell = document.createElement('td');
+///        classCell.className = 'govuk-table__cell';
+///        classCell.textContent = instance.instance_class || 'N/A';
+///        
+///        // Region
+///        const regionCell = document.createElement('td');
+///        regionCell.className = 'govuk-table__cell';
+///        regionCell.textContent = instance.region || 'N/A';
+///        
+///        // Status
+///        const statusCell = document.createElement('td');
+///        statusCell.className = 'govuk-table__cell';
+///        const statusTag = document.createElement('span');
+///        statusTag.className = `status-tag status-tag--${instance.status.toLowerCase()}`;
+///        statusTag.textContent = instance.status;
+///        statusCell.appendChild(statusTag);
+///        
+///        // Actions
+///        const actionsCell = document.createElement('td');
+///        actionsCell.className = 'govuk-table__cell';
+///        
+///        const viewButton = document.createElement('a');
+///        viewButton.href = `/rds/${encodeURIComponent(instance.instance_id)}`;
+///        viewButton.className = 'govuk-button govuk-button--secondary govuk-button--small';
+///        viewButton.textContent = 'View Details';
+///        actionsCell.appendChild(viewButton);
+///        
+///        // Append all cells
+///        row.appendChild(idCell);
+///        row.appendChild(appCell);
+///        row.appendChild(envCell);
+///        row.appendChild(versionCell);
+///        row.appendChild(complianceCell);
+///        row.appendChild(classCell);
+///        row.appendChild(regionCell);
+///        row.appendChild(statusCell);
+///        row.appendChild(actionsCell);
+///        
+///        return row;
+///    }
+///
+///    createComplianceTag(instance) {
+///        const tag = document.createElement('span');
+///        
+///        if (instance.is_eol) {
+///            tag.className = 'compliance-tag compliance-tag--critical';
+///            tag.textContent = 'End-of-Life';
+///            tag.title = 'This version is end-of-life and should be upgraded immediately';
+///        } else {
+///            // Could add logic for outdated detection here
+///            const isOutdated = this.isInstanceOutdated(instance);
+///            if (isOutdated) {
+///                tag.className = 'compliance-tag compliance-tag--warning';
+///                tag.textContent = 'Outdated';
+///                tag.title = 'This version is outdated and should be updated';
+///            } else {
+///                tag.className = 'compliance-tag compliance-tag--success';
+///                tag.textContent = 'Compliant';
+///                tag.title = 'This version is current and compliant';
+///            }
+///        }
+///        
+///        return tag;
+///    }
+///
+///    isInstanceOutdated(instance) {
+///        // Simple heuristic: versions below 13 are considered outdated (but not EOL)
+///        const majorVersion = parseInt(instance.major_version);
+///        return !instance.is_eol && majorVersion < 13;
+///    }
+///
+///    getComplianceStatus(instance) {
+///        if (instance.is_eol) return 'eol';
+///        if (this.isInstanceOutdated(instance)) return 'outdated';
+///        return 'compliant';
+///    }
+///
+///    handleSearch(searchTerm) {
+///        this.currentSearch = searchTerm.toLowerCase().trim();
+///        this.applyFiltersAndSearch();
+///    }
+///
+///    handleFilter(filter) {
+///        this.currentFilter = filter;
+///        this.applyFiltersAndSearch();
+///    }
+///
+///    applyFiltersAndSearch() {
+///        let filtered = [...this.instances];
+///        
+///        // Apply filter
+///        if (this.currentFilter !== 'all') {
+///            filtered = filtered.filter(instance => {
+///                const status = this.getComplianceStatus(instance);
+///                return status === this.currentFilter;
+///            });
+///        }
+///        
+///        // Apply search
+///        if (this.currentSearch) {
+///            filtered = filtered.filter(instance => 
+///                instance.instance_id.toLowerCase().includes(this.currentSearch) ||
+///                (instance.application || '').toLowerCase().includes(this.currentSearch) ||
+///                (instance.environment || '').toLowerCase().includes(this.currentSearch) ||
+///                instance.version.toLowerCase().includes(this.currentSearch) ||
+///                instance.major_version.toLowerCase().includes(this.currentSearch) ||
+///                (instance.region || '').toLowerCase().includes(this.currentSearch)
+///            );
+///        }
+///        
+///        this.filteredInstances = filtered;
+///        this.renderInstances();
+///    }
+///
+///    handleSort(field) {
+///        if (this.currentSort.field === field) {
+///            // Toggle direction
+///            this.currentSort.direction = this.currentSort.direction === 'asc' ? 'desc' : 'asc';
+///        } else {
+///            // New field, default to ascending
+///            this.currentSort.field = field;
+///            this.currentSort.direction = 'asc';
+///        }
+///        
+///        this.updateSortIndicators();
+///        this.renderInstances();
+///    }
+///
+///    sortInstances() {
+///        this.filteredInstances.sort((a, b) => {
+///            let aValue, bValue;
+///            
+///            switch (this.currentSort.field) {
+///                case 'instance_id':
+///                    aValue = a.instance_id.toLowerCase();
+///                    bValue = b.instance_id.toLowerCase();
+///                    break;
+///                case 'application':
+///                    aValue = (a.application || '').toLowerCase();
+///                    bValue = (b.application || '').toLowerCase();
+///                    break;
+///                case 'environment':
+///                    aValue = (a.environment || '').toLowerCase();
+///                    bValue = (b.environment || '').toLowerCase();
+///                    break;
+///                case 'version':
+///                    aValue = a.version.toLowerCase();
+///                    bValue = b.version.toLowerCase();
+///                    break;
+///                case 'instance_class':
+///                    aValue = (a.instance_class || '').toLowerCase();
+///                    bValue = (b.instance_class || '').toLowerCase();
+///                    break;
+///                case 'region':
+///                    aValue = (a.region || '').toLowerCase();
+///                    bValue = (b.region || '').toLowerCase();
+///                    break;
+///                default:
+///                    return 0;
+///            }
+///            
+///            if (aValue < bValue) return this.currentSort.direction === 'asc' ? -1 : 1;
+///            if (aValue > bValue) return this.currentSort.direction === 'asc' ? 1 : -1;
+///            return 0;
+///        });
+///    }
+///
+///    updateSortIndicators() {
+///        // Reset all sort indicators
+///        document.querySelectorAll('.sortable').forEach(header => {
+///            header.classList.remove('asc', 'desc');
+///        });
+///        
+///        // Set current sort indicator
+///        const currentHeader = document.querySelector(`[data-sort="${this.currentSort.field}"]`);
+///        if (currentHeader) {
+///            currentHeader.classList.add(this.currentSort.direction);
+///        }
+///    }
+///
+///    setActiveFilter(activeButton) {
+///        // Remove active class from all filter buttons
+///        document.querySelectorAll('[data-filter]').forEach(button => {
+///            button.classList.remove('active');
+///        });
+///        
+///        // Add active class to clicked button
+///        activeButton.classList.add('active');
+///    }
+///
+///    clearAllFilters() {
+///        this.currentFilter = 'all';
+///        this.currentSearch = '';
+///        
+///        // Reset UI elements
+///        document.getElementById('search-instances').value = '';
+///        this.setActiveFilter(document.getElementById('filter-all'));
+///        
+///        // Reapply filters
+///        this.applyFiltersAndSearch();
+///    }
+///
+///    updateTableFooter() {
+///        document.getElementById('visible-count').textContent = this.filteredInstances.length;
+///        document.getElementById('total-count').textContent = this.instances.length;
+///        
+///        const filterInfo = document.getElementById('filter-info');
+///        if (this.currentFilter !== 'all' || this.currentSearch) {
+///            let filterText = '';
+///            if (this.currentFilter !== 'all') {
+///                filterText += ` • Filtered by: ${this.currentFilter}`;
+///            }
+///            if (this.currentSearch) {
+///                filterText += ` • Search: "${this.currentSearch}"`;
+///            }
+///            filterInfo.textContent = filterText;
+///        } else {
+///            filterInfo.textContent = '';
+///        }
+///    }
+///
+///    renderVersionChart() {
+///        // Simple version distribution display
+///        const chartContainer = document.getElementById('version-chart-container');
+///        const versionSummary = document.getElementById('version-summary');
+///        
+///        if (!chartContainer || !versionSummary) return;
+///        
+///        // Count versions
+///        const versionCounts = {};
+///        this.instances.forEach(instance => {
+///            const version = instance.major_version;
+///            versionCounts[version] = (versionCounts[version] || 0) + 1;
+///        });
+///        
+///        // Create version summary
+///        let summaryHTML = '<div class="version-distribution">';
+///        Object.entries(versionCounts)
+///            .sort((a, b) => b[0] - a[0]) // Sort by version descending
+///            .forEach(([version, count]) => {
+///                const percentage = ((count / this.instances.length) * 100).toFixed(1);
+///                summaryHTML += `
+///                    <div class="version-item">
+///                        <span class="version-label">PostgreSQL ${version}</span>
+///                        <span class="version-count">${count} instances (${percentage}%)</span>
+///                    </div>
+///                `;
+///            });
+///        summaryHTML += '</div>';
+///        
+///        versionSummary.innerHTML = summaryHTML;
+///        chartContainer.style.display = 'block';
+///    }
+///
+    showLoading() {
+        const loadingState = document.getElementById('loading-state');
+        if (loadingState) {
+            loadingState.style.display = 'block';
+        }
+    }
+
+    hideLoading() {
+        const loadingState = document.getElementById('loading-state');
+        if (loadingState) {
+            loadingState.style.display = 'none';
+        }
+    }
+
+    showError(message) {
+        const errorState = document.getElementById('error-state');
+        const errorMessage = document.getElementById('error-message');
+        
+        if (errorState) {
+            errorState.style.display = 'block';
+        }
+        
+        if (errorMessage) {
+            errorMessage.textContent = message || 'Failed to load ElastiCache data. Please try again.';
+        }
+    }
+
+    hideError() {
+        const errorState = document.getElementById('error-state');
+        if (errorState) {
+            errorState.style.display = 'none';
+        }
+    }
+///
+///    showInstancesTable() {
+///        const container = document.getElementById('instances-container');
+///        if (container) {
+///            container.style.display = 'block';
+///        }
+///    }
+///
+///    showNoResults() {
+///        const noResults = document.getElementById('no-results');
+///        if (noResults) {
+///            noResults.style.display = 'block';
+///        }
+///    }
+///
+///    hideNoResults() {
+///        const noResults = document.getElementById('no-results');
+///        if (noResults) {
+///            noResults.style.display = 'none';
+///        }
+///    }
+}
+
+// Initialize RDS page when DOM is ready
+document.addEventListener('DOMContentLoaded', () => {
+    new ElastiCachesPage();
+});
+
+// Add comprehensive CSS for RDS styling
+const elastiCacheStyle = document.createElement('style');
+elastiCacheStyle.textContent = `
+    /* ElastiCache Summary Cards */
+    .elasticache-summary-card {
+        border: 2px solid #b1b4b6;
+        border-radius: 4px;
+        padding: 20px;
+        margin-bottom: 20px;
+        background: #ffffff;
+        text-align: center;
+    }
+    
+    .elasticache-summary-card--success {
+        border-color: #00703c;
+        background-color: #f3fff3;
+    }
+    
+    .elasticache-summary-card--warning {
+        border-color: #f47738;
+        background-color: #fff8f0;
+    }
+    
+    .elasticache-summary-card--critical {
+        border-color: #d4351c;
+        background-color: #fff5f5;
+    }
+    
+    .elasticache-metric-value {
+        font-size: 32px;
+        font-weight: bold;
+        margin: 10px 0;
+        color: #0b0c0c;
+    }
+    
+    .elasticache-metric-value.success {
+        color: #00703c;
+    }
+    
+    .elasticache-metric-value.warning {
+        color: #f47738;
+    }
+    
+    .elasticache-metric-value.critical {
+        color: #d4351c;
+    }
+    
+    .elasticache-metric-subtitle {
+        font-size: 14px;
+        color: #505a5f;
+        margin: 0;
+    }
+    
+    /* RDS Filters */
+    .rds-filters {
+        padding: 20px;
+        background: #f8f8f8;
+        border-radius: 4px;
+        margin-bottom: 20px;
+    }
+    
+    .filter-buttons {
+        margin-top: 15px;
+        display: flex;
+        gap: 10px;
+        flex-wrap: wrap;
+    }
+    
+    .filter-buttons .govuk-button {
+        margin: 0;
+    }
+    
+    .filter-buttons .govuk-button.active {
+        background-color: #1d70b8;
+        color: white;
+        border-color: #1d70b8;
+    }
+    
+    /* RDS Table Styling */
+    .rds-instances-table {
+        margin-top: 0;
+    }
+    
+    .rds-row--critical {
+        background-color: #fff5f5;
+        border-left: 4px solid #d4351c;
+    }
+    
+    .rds-row--warning {
+        background-color: #fff8f0;
+        border-left: 4px solid #f47738;
+    }
+    
+    /* Compliance Tags */
+    .compliance-tag {
+        padding: 4px 8px;
+        border-radius: 3px;
+        font-size: 12px;
+        font-weight: bold;
+        text-transform: uppercase;
+        display: inline-block;
+    }
+    
+    .compliance-tag--success {
+        background-color: #00703c;
+        color: white;
+    }
+    
+    .compliance-tag--warning {
+        background-color: #f47738;
+        color: white;
+    }
+    
+    .compliance-tag--critical {
+        background-color: #d4351c;
+        color: white;
+    }
+    
+    /* Environment Tags */
+    .environment-tag {
+        padding: 2px 6px;
+        border-radius: 3px;
+        font-size: 11px;
+        font-weight: bold;
+        text-transform: uppercase;
+        display: inline-block;
+    }
+    
+    .environment-tag--production {
+        background-color: #d4351c;
+        color: white;
+    }
+    
+    .environment-tag--staging {
+        background-color: #f47738;
+        color: white;
+    }
+    
+    .environment-tag--development {
+        background-color: #1d70b8;
+        color: white;
+    }
+    
+    .environment-tag--test {
+        background-color: #7a2e8d;
+        color: white;
+    }
+    
+    .environment-tag--unknown {
+        background-color: #505a5f;
+        color: white;
+    }
+    
+    /* Status Tags */
+    .status-tag {
+        padding: 2px 6px;
+        border-radius: 3px;
+        font-size: 11px;
+        font-weight: bold;
+        display: inline-block;
+    }
+    
+    .status-tag--available {
+        background-color: #00703c;
+        color: white;
+    }
+    
+    .status-tag--stopped {
+        background-color: #d4351c;
+        color: white;
+    }
+    
+    .status-tag--starting {
+        background-color: #f47738;
+        color: white;
+    }
+    
+    .status-tag--stopping {
+        background-color: #f47738;
+        color: white;
+    }
+    
+    /* Version Information */
+    .version-info {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    
+    .version-major {
+        color: #505a5f;
+        font-size: 11px;
+        margin-top: 2px;
+    }
+    
+    /* Small buttons */
+    .govuk-button--small {
+        font-size: 14px;
+        padding: 5px 10px;
+    }
+    
+    /* Action buttons */
+    .action-buttons {
+        margin: 20px 0;
+        display: flex;
+        gap: 15px;
+        flex-wrap: wrap;
+    }
+    
+    .action-buttons .govuk-button {
+        margin: 0;
+    }
+    
+    /* Table footer */
+    .table-footer {
+        margin-top: 15px;
+        padding: 10px 0;
+        border-top: 1px solid #b1b4b6;
+    }
+    
+    /* No results state */
+    .no-results {
+        text-align: center;
+        padding: 40px;
+        background: #f8f8f8;
+        border-radius: 4px;
+        margin-top: 20px;
+    }
+    
+    /* Sort indicators */
+    .sortable {
+        cursor: pointer;
+        position: relative;
+    }
+    
+    .sortable:hover {
+        background-color: #f8f8f8;
+    }
+    
+    .sort-arrow {
+        margin-left: 5px;
+        opacity: 0.3;
+    }
+    
+    .sortable.asc .sort-arrow::after {
+        content: "↑";
+        opacity: 1;
+    }
+    
+    .sortable.desc .sort-arrow::after {
+        content: "↓";
+        opacity: 1;
+    }
+    
+    /* Version distribution chart */
+    .chart-placeholder {
+        padding: 20px;
+        background: #f8f8f8;
+        border-radius: 4px;
+        text-align: center;
+    }
+    
+    .version-distribution {
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        gap: 15px;
+        margin-top: 20px;
+    }
+    
+    .version-item {
+        padding: 15px;
+        background: white;
+        border-radius: 4px;
+        border: 1px solid #b1b4b6;
+        text-align: left;
+    }
+    
+    .version-label {
+        display: block;
+        font-weight: bold;
+        margin-bottom: 5px;
+    }
+    
+    .version-count {
+        display: block;
+        color: #505a5f;
+        font-size: 14px;
+    }
+    
+    /* Loading and error states */
+    .loading-container {
+        text-align: center;
+        padding: 40px;
+    }
+    
+    .loading-spinner {
+        border: 4px solid #f3f2f1;
+        border-top: 4px solid #1d70b8;
+        border-radius: 50%;
+        width: 40px;
+        height: 40px;
+        animation: spin 1s linear infinite;
+        margin: 0 auto 20px;
+    }
+    
+    @keyframes spin {
+        0% { transform: rotate(0deg); }
+        100% { transform: rotate(360deg); }
+    }
+    
+    .error-container {
+        margin: 20px 0;
+    }
+    
+    /* Responsive design */
+    @media (max-width: 768px) {
+        .filter-buttons {
+            flex-direction: column;
+        }
+        
+        .action-buttons {
+            flex-direction: column;
+        }
+        
+        .version-distribution {
+            grid-template-columns: 1fr;
+        }
+        
+        .rds-instances-table {
+            font-size: 14px;
+        }
+        
+        .govuk-table__cell {
+            padding: 8px 4px;
+        }
+    }
+`;
+document.head.appendChild(elastiCacheStyle);

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -148,6 +148,56 @@
                         </div>
                     </div>
                 </div>
+
+                <!-- ElastiCache Updates Checker Module -->
+                <div class="govuk-grid-column-one-half">
+                    <div class="report-module-card" id="elasticache-module">
+                        <div class="report-module-header">
+                            <h2 class="govuk-heading-m">ElastiCache Version Checker</h2>
+                            <span class="module-status" id="elasticache-status">
+                                <span class="status-indicator loading"></span>
+                                Loading...
+                            </span>
+                        </div>
+
+                        <div class="report-module-content">
+                            <p class="govuk-body">Monitor ElastiCaches and update compliance</p>
+
+                            <!-- RDS Summary Metrics -->
+                            <div class="module-metrics" id="elasticache-metrics">
+                                <div class="metric">
+                                    <span class="metric-label">Serverless Clusters</span>
+                                    <span class="metric-value" id="elasticache-serverless-clusters">Loading...</span>
+                                </div>
+                                <div class="metric">
+                                    <span class="metric-label">Replication Groups</span>
+                                    <span class="metric-value alert" id="elasticache-replication-groups">Loading...</span>
+                                </div>
+                                <div class="metric">
+                                    <span class="metric-label">Non Replicated Cache Clusters</span>
+                                    <span class="metric-value" id="elasticache-non-replicated-cache-clusters">Loading...</span>
+                                </div>
+                                <div class="metric">
+                                    <span class="metric-label">Unapplied Critical Updates</span>
+                                    <span class="metric-value" id="elasticache-unapplied-critical-updates">Loading...</span>
+                                </div>
+                                <div class="metric">
+                                    <span class="metric-label">Unapplied Important Updates</span>
+                                    <span class="metric-value" id="elasticache-unapplied-important-updates">Loading...</span>
+                                </div>
+                            </div>
+
+                            <div class="module-actions">
+                                <a href="/elasticache" class="govuk-button govuk-button--secondary">
+                                    View ElastiCaches
+                                </a>
+                                <a href="/api/reports/elasticache" class="govuk-link" target="_blank">
+                                    API Data
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+
             </div>
 
             <!-- Quick Actions -->

--- a/web/templates/dashboard.html
+++ b/web/templates/dashboard.html
@@ -163,7 +163,7 @@
                         <div class="report-module-content">
                             <p class="govuk-body">Monitor ElastiCaches and update compliance</p>
 
-                            <!-- RDS Summary Metrics -->
+                            <!-- ElastiCache Summary Metrics -->
                             <div class="module-metrics" id="elasticache-metrics">
                                 <div class="metric">
                                     <span class="metric-label">Serverless Clusters</span>

--- a/web/templates/elasticaches.html
+++ b/web/templates/elasticaches.html
@@ -106,6 +106,30 @@
                 </div>
             </div>
 
+            <!-- ElastiCaches Table -->
+            <div class="govuk-grid-row" id="caches-container" style="display: none;">
+                <div class="govuk-grid-column-full">
+                    <h2 class="govuk-heading-l">ElastiCaches</h2>
+                    <div class="table-container">
+                        <table class="govuk-table" id="caches-table">
+                            <thead class="govuk-table__head">
+                                <tr class="govuk-table__row">
+                                    <th scope="col" class="govuk-table__header">Name</th>
+                                    <th scope="col" class="govuk-table__header">Type</th>
+                                    <th scope="col" class="govuk-table__header">Engine</th>
+                                    <th scope="col" class="govuk-table__header">Version</th>
+                                    <th scope="col" class="govuk-table__header">Critical Updates</th>
+                                    <th scope="col" class="govuk-table__header">Important Updates</th>
+                                    <th scope="col" class="govuk-table__header">Total Updates</th>
+                                </tr>
+                            </thead>
+                            <tbody class="govuk-table__body" id="caches-tbody">
+                                <!-- Instances will be populated by JavaScript -->
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+            </div>
         </main>
     </div>
 

--- a/web/templates/elasticaches.html
+++ b/web/templates/elasticaches.html
@@ -1,0 +1,140 @@
+<!DOCTYPE html>
+<html lang="en" class="govuk-template">
+<head>
+    <meta charset="utf-8">
+    <title>{{.title}}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+    <meta name="theme-color" content="#0b0c0c">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <link rel="stylesheet" href="/static/css/dashboard.css">
+    <link rel="icon" type="image/x-icon" href="/static/images/favicon.ico">
+</head>
+
+<body class="govuk-template__body">
+    <script>document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');</script>
+
+    <header class="govuk-header" role="banner" data-module="govuk-header">
+        <div class="govuk-header__container govuk-width-container">
+            <div class="govuk-header__logo">
+                <a href="/" class="govuk-header__link govuk-header__link--homepage">
+                    <span class="govuk-header__logotype">
+                        <span class="govuk-header__logotype-text">GOV.UK</span>
+                    </span>
+                </a>
+            </div>
+            <div class="govuk-header__content">
+                <a href="/" class="govuk-header__link govuk-header__link--service-name">
+                    Reports Dashboard
+                </a>
+            </div>
+        </div>
+    </header>
+
+    <div class="govuk-width-container">
+        <main class="govuk-main-wrapper" id="main-content" role="main">
+            
+            <!-- Breadcrumbs -->
+            <div class="govuk-breadcrumbs">
+                <ol class="govuk-breadcrumbs__list">
+                    <li class="govuk-breadcrumbs__list-item">
+                        <a class="govuk-breadcrumbs__link" href="/">Dashboard</a>
+                    </li>
+                    <li class="govuk-breadcrumbs__list-item">
+                        ElastiCaches
+                    </li>
+                </ol>
+            </div>
+
+            <!-- Page Header -->
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-full">
+                    <h1 class="govuk-heading-xl">ElastiCaches</h1>
+                    <p class="govuk-body-l">Monitor ElastiCaches, their update status, and version compliance across GOV.UK</p>
+                </div>
+            </div>
+
+            <!-- Summary Cards -->
+            <div class="govuk-grid-row" id="summary-cards">
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="elasticache-summary-card">
+                        <h3 class="govuk-heading-s">Total Caches</h3>
+                        <p class="elasticache-metric-value" id="total-elasticaches">Loading...</p>
+                        <p class="elasticache-metric-subtitle">total elasticaches</p>
+                    </div>
+                </div>
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="elasticache-summary-card elasticache-summary-card">
+                        <h3 class="govuk-heading-s">Total&nbsp;Updates</h3>
+                        <p class="elasticache-metric-value critial" id="unapplied-updates">Loading...</p>
+                        <p class="elasticache-metric-subtitle">All updates waiting</p>
+                    </div>
+                </div>
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="elasticache-summary-card elasticache-summary-card">
+                        <h3 class="govuk-heading-s">Important&nbsp;Updates</h3>
+                        <p class="elasticache-metric-value" id="unapplied-important-updates">Loading...</p>
+                        <p class="elasticache-metric-subtitle">Important updates waiting</p>
+                    </div>
+                </div>
+                <div class="govuk-grid-column-one-quarter">
+                    <div class="elasticache-summary-card elasticache-summary-card">
+                        <h3 class="govuk-heading-s">Critical&nbsp;Updates</h3>
+                        <p class="elasticache-metric-value" id="unapplied-critical-updates">Loading...</p>
+                        <p class="elasticache-metric-subtitle">Critical updates waiting</p>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Loading State -->
+            <div id="loading-state" class="loading-container">
+                <div class="loading-spinner"></div>
+                <p class="govuk-body">Loading ElastiCache data...</p>
+            </div>
+
+            <!-- Error State -->
+            <div id="error-state" class="error-container" style="display: none;">
+                <div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert">
+                    <h2 class="govuk-error-summary__title" id="error-summary-title">
+                        There is a problem
+                    </h2>
+                    <div class="govuk-error-summary__body">
+                        <p id="error-message">Failed to load ElastiCache data. Please try again.</p>
+                        <button class="govuk-button govuk-button--secondary" id="retry-button">
+                            Retry
+                        </button>
+                    </div>
+                </div>
+            </div>
+
+        </main>
+    </div>
+
+    <footer class="govuk-footer" role="contentinfo">
+        <div class="govuk-width-container">
+            <div class="govuk-footer__meta">
+                <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+                    <h2 class="govuk-visually-hidden">Support links</h2>
+                    <ul class="govuk-footer__inline-list">
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="/api/health">API Health</a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="/api/rds/health">RDS Health</a>
+                        </li>
+                        <li class="govuk-footer__inline-list-item">
+                            <a class="govuk-footer__link" href="https://github.com/alphagov">GOV.UK on GitHub</a>
+                        </li>
+                    </ul>
+                </div>
+                <div class="govuk-footer__meta-item">
+                    <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">
+                        © Crown copyright
+                    </a>
+                </div>
+            </div>
+        </div>
+    </footer>
+
+    <script src="/static/js/elasticache.js"></script>
+</body>
+</html>

--- a/web/templates/elasticaches.html
+++ b/web/templates/elasticaches.html
@@ -143,7 +143,7 @@
                             <a class="govuk-footer__link" href="/api/health">API Health</a>
                         </li>
                         <li class="govuk-footer__inline-list-item">
-                            <a class="govuk-footer__link" href="/api/rds/health">RDS Health</a>
+                            <a class="govuk-footer__link" href="/api/elasticache/health">ElastiCache Health</a>
                         </li>
                         <li class="govuk-footer__inline-list-item">
                             <a class="govuk-footer__link" href="https://github.com/alphagov">GOV.UK on GitHub</a>


### PR DESCRIPTION
The elasticache API is a bit annoying since each category of cache has it's own describe endpoint, and then there is a separate endpoint to get information about udpates (which returns updates which have already been applied, and also that might not be applicable). So generating the summary requires at least 4 API calls (and I split the updates call into 1 call for cache cluster updates, and 1 call for replication group updates, so it's 5 API calls, not including any pagination related extra calls)

Add 

* ElastiCache types, models, and handlers
* Add to the api:
  * /api/elasticache/health
  * /api/elasticache/summary to get summary of all ElastiCaches, this gets:
    * Cache Clusters
    * Replication Groups
    * Serverless Caches
* Elasticaches UI page on /elasticache which displays:
  * Total number of caches
  * Total updates that remain unapplied
  * Important updates that remain unapplied
  * Critical updates that remain unapplied
  * A list of all caches ordered by name displaying:
    * Name
    * Type (Serverless, Replication Group, or Cache Cluster)
    * Engine
    * Engine Version
    * Number of critical, important, and total updates
 * Skeleton elasticache report which only reports if elasticache can be queried
 * Summary ElastiCache box on the dashboard page
   * Currently only the availability indicator works, but it's ready to take info on number of different cluster types, and number of unapplied critical and important updates
   * Has a link to the /elasticache page

Screenshots showing the above:

Dashboard summary card
![Screenshot 2025-07-04 at 11 03 57](https://github.com/user-attachments/assets/e4af18b1-f014-414c-894c-e44c56302978)

Elasticaches page (from integration)
![Screenshot 2025-07-04 at 11 04 46](https://github.com/user-attachments/assets/f665497e-26fb-4d89-8c79-8db3bf86a5b5)


