### PR TITLE
[PNP-9879] Remove government-frontend

### DIFF
--- a/internal/modules/costs/application.go
+++ b/internal/modules/costs/application.go
@@ -237,7 +237,6 @@ func (s *ApplicationService) mapAppNameToSystemTag(app govuk.Application) string
 		"publishing-api":           "govuk-publishing-api",
 		"content-store":            "govuk-content-store",
 		"frontend":                 "govuk-frontend",
-		"government-frontend":      "govuk-government-frontend",
 		"collections":              "govuk-collections",
 		"finder-frontend":          "govuk-finder-frontend",
 		"whitehall":                "govuk-whitehall",


### PR DESCRIPTION
government-frontend has been consolidated
into Frontend and the app is now being retired.

[Jira card](https://gov-uk.atlassian.net/browse/PNP-9879)